### PR TITLE
pkg/compiler: fix excessive deref

### DIFF
--- a/pkg/compiler/luaUtil.go
+++ b/pkg/compiler/luaUtil.go
@@ -673,7 +673,7 @@ func getChannelFromGlobal(lvm *LuaVm, varname string, leaveOnTop bool) (interfac
 		// cleanup
 		vm.Pop(1)
 	}
-	return (*i.(*reflect.Value)).Interface(), nil
+	return i.(*reflect.Value).Interface(), nil
 }
 
 func intMin(a, b int) int {


### PR DESCRIPTION
The `(*x.(*T)).M()` is identical to `x.(*T).M()`,
since Go does one level auto-deref automatically.

Note that *x in the code above does not perform
extra copying as the machine code generated for
both forms will be the same.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>